### PR TITLE
chore: polish SKILL front-matter metadata

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: banana-claws
 description: Generate images via OpenRouter API (text-to-image) with automation-ready local scripts and a queue-first workflow. Use for single images or batched variants (posters, thumbnails, illustrations, concept art), especially when agents must acknowledge quickly, process asynchronously, and return consolidated file attachments with structured success/failure records.
-metadata:
-  {
-    "openclaw": {
-      "requires": {
-        "bins": ["python3"],
-        "env": ["OPENROUTER_API_KEY"]
-      }
-    }
-  }
+homepage: https://github.com/ironystock/banana-claws
+user-invocable: true
+metadata: {"openclaw":{"emoji":"🍌","primaryEnv":"OPENROUTER_API_KEY","requires":{"bins":["python3"],"env":["OPENROUTER_API_KEY"]}}}
 ---
 
 # OpenRouter Image Generation


### PR DESCRIPTION
## Changed
- set `homepage` to GitHub repo
- set `user-invocable: true` (keep slash command exposure)
- converted `metadata` to single-line JSON object for parser compatibility
- added `openclaw.emoji` = 🍌
- added `openclaw.primaryEnv` = `OPENROUTER_API_KEY`
- retained `requires.bins` + `requires.env`

## Why
Align with OpenClaw skill docs recommendations and your desired slash-command exposure + banana emoji identity.
